### PR TITLE
Using an Edge-compatible value for browser_actions.default_icon…

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,8 +7,10 @@
       "run_at": "document_start"
    } ],
    "browser_action": {
-     "default_icon": "icon.png",
-	 "default_title": "Debug WebRTC"
+      "default_icon": {
+         "38": "icon.png"
+      },
+      "default_title": "Debug WebRTC"
    },
   "background": {
     "scripts": ["opentab.js"],


### PR DESCRIPTION
… in manifest.json

Edge does not support the simple string value that was used.
See: https://docs.microsoft.com/en-us/microsoft-edge/extensions/api-support/supported-manifest-keys
(prevents installation on Edge)